### PR TITLE
Remove player view window toolbar shortcut.

### DIFF
--- a/src/main/ogre/tools/render/toolbar.cljs
+++ b/src/main/ogre/tools/render/toolbar.cljs
@@ -112,7 +112,7 @@
         {:css {:active (:share/open? data)}
          :on-click #(dispatch :share/initiate)
          :on-mouse-enter (tooltip-fn :share/open)}
-        [icon {:name "pip" :size 22}] [shortcut "W"]]
+        [icon {:name "pip" :size 22}]]
        [:button
         {:disabled (or (not (:share/open? data)) (not (:share/paused? data)))
          :on-click #(dispatch :share/switch)

--- a/src/main/ogre/tools/shortcut.cljs
+++ b/src/main/ogre/tools/shortcut.cljs
@@ -82,10 +82,6 @@
        (if open?
          (dispatch :share/switch))))
 
-   ["keydown" \w]
-   (fn [[_ dispatch]]
-     (dispatch :share/initiate))
-
    ["keydown" \ ]
    (fn [[_ dispatch]]
      (dispatch :interface/toggle-panel))


### PR DESCRIPTION
Fixes #13 by removing the player view window shortcut altogether.