### PR TITLE
Render conditions on token.

### DIFF
--- a/web/release/ogre.tools.css
+++ b/web/release/ogre.tools.css
@@ -469,6 +469,15 @@ legend {
     text-anchor: middle;
 }
 
+.canvas-token-flags {
+    pointer-events: none;
+    color: var(--theme-text);
+}
+
+.canvas-token-flags circle {
+    fill: var(--theme-background-d);
+}
+
 @keyframes ring-pulse {
     0%   { transform: scale(1); }
     100% { transform: scale(1.3); }


### PR DESCRIPTION
Resolves #17 by adding up to 6 condition icons surrounding each token. Does not display some flags such as `:player`, `:hidden`, and `:unconscious` since we use (or will use) alternative visual cues for these flags.